### PR TITLE
Add docker devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-1-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends python3-pip pex
+
+RUN git clone https://github.com/facebook/folly -b v2025.08.25.00 /folly
+
+WORKDIR /folly
+
+# System fast-float is not fresh enough - avoid installing it from dpkg and build manually
+RUN sed -i 's/fast_float//' /folly/build/fbcode_builder/manifests/folly \
+    && sed -i 's/cmd_argss.append(\["pip", "install", "pex"\])//' /folly/build/fbcode_builder/getdeps.py
+
+RUN python3 ./build/fbcode_builder/getdeps.py install-system-deps --recursive
+
+RUN git clone https://github.com/fastfloat/fast_float.git -b v8.0.2 /fast_float \
+    && cmake -S /fast_float -B /fast_float/build \
+    && cmake --build /fast_float/build \
+    && cmake --install /fast_float/build \
+    && rm -rf /fast_float/build
+
+RUN python3 ./build/fbcode_builder/getdeps.py --allow-system-packages build --no-tests \
+    && python3 ./build/fbcode_builder/getdeps.py show-build-dir \
+    && rm -rf $(./build/fbcode_builder/getdeps.py show-scratch-dir)/build
+
+RUN mkdir -p /devcontainer
+RUN ln -s $(python3 ./build/fbcode_builder/getdeps.py show-inst-dir)/include /devcontainer/folly-include
+RUN ln -s $(python3 ./build/fbcode_builder/getdeps.py show-inst-dir)/lib /devcontainer/folly-lib
+# Dependency - fmt
+RUN ln -s $(python3 ./build/fbcode_builder/getdeps.py show-scratch-dir)/installed/fmt*/include /devcontainer/fmt-include
+RUN ln -s $(python3 ./build/fbcode_builder/getdeps.py show-scratch-dir)/installed/fmt*/lib /devcontainer/fmt-lib

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Rust",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    // "image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+    "build": {
+      "dockerfile": "Dockerfile"
+    }
+
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	// "mounts": [
+	// 	{
+	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+	// 		"target": "/usr/local/cargo",
+	// 		"type": "volume"
+	// 	}
+	// ]
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+    //	 "postCreateCommand": [],
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/build.rs
+++ b/build.rs
@@ -2,10 +2,16 @@ fn main() {
     cxx_build::bridge("src/main.rs")
         .file("src/indexshim.cpp")
         .include("/opt/homebrew/include")
+        // These includes are to use in devcontainer
+        .include("/devcontainer/folly-include")
+        .include("/devcontainer/fmt-include")
         .std("c++17")
         .compile("rust_cxx");
 
     println!("cargo:rustc-link-search=native=/opt/homebrew/lib");
+    // These imports are to use in devcontainer
+    println!("cargo:rustc-link-search=native=/devcontainer/folly-lib");
+    println!("cargo:rustc-link-search=native=/devcontainer/fmt-lib");
 
     // println!("cargo:rustc-link-lib=static=folly");
 
@@ -19,6 +25,9 @@ fn main() {
     // println!("cargo:rustc-link-lib=static=snappy");
     // println!("cargo:rustc-link-lib=static=event_pthreads");
     // println!("cargo:rustc-link-lib=static=boost_context");
+    // println!("cargo:rustc-link-lib=static=boost_program_options");
+    // // For devcontainer: use dynamic linking to unwind
+    // println!("cargo:rustc-link-lib=dylib=unwind");
 
     println!("cargo:rerun-if-changed=include/index.h");
     println!("cargo:rerun-if-changed=include/indexshim.h");


### PR DESCRIPTION
Setting up the folly build could be somewhat tricky, especially on Linux machines or older Intel Macs. Let's add devcontainer build as an escape hatch.

The usage is straightforward - just open the checked repo in VS Code or any other IDE and choose "Open in devcontainer" ([devcontainer plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) should be installed). A custom Rust-based image with Folly preinstalled is built.

The `build.rs` is updated to support custom paths for Folly in devcontainers.